### PR TITLE
replaced findit with walkdir which works on windows

### DIFF
--- a/bin/ejs-amd
+++ b/bin/ejs-amd
@@ -27,18 +27,18 @@ if (!program.from && !program.to) {
 console.log();
 process.on("exit", console.log);
 
-var finder = require("findit").find(program.from);
+var finder = require("walkdir").walk(program.from);
 
 finder.on("file", function (file) {
   var suffixRe = /\.ejs$/;
-  if ( suffixRe.test(file) ) { 
-
-    var local_path = file.replace( new RegExp("^" + program.from + "/+"), "");
-    var fromPath = path.join( program.from, local_path);
-    var toPath   = path.join( program.to, local_path).replace(suffixRe, ".js");
-
-    renderFile( fromPath, toPath );
+  if ( suffixRe.test(file) ) {
+    var toPath = path.resolve(".", program.to, path.basename(file, '.ejs') + ".js")
+    renderFile(file, toPath );
   }
+});
+
+finder.on("error", function(err) {
+  console.log('ERROR reading:' + err);
 });
 
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ejs": "~0.8.3",
     "commander": "~1.0.4",
     "mkdirp": "~0.3.4",
-    "findit": "~0.1.2"
+    "walkdir": "0.0.5"
   },
   "devDependencies": {
     "should": "~1.2.0",


### PR DESCRIPTION
- findit has an issue with inode which doesn't exist in windows giving false positives.
- replaced with walkdir which does not rely on that. 
- tested on mac and windows and works on both
