### PR TITLE
update to ejs 2.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "BSD",
   "dependencies": {
-    "ejs": "~0.8.3",
+    "ejs": "~2.3.3",
     "commander": "~1.0.4",
     "mkdirp": "~0.3.4",
     "walkdir": "0.0.5"

--- a/test/fixture/custom.ejs
+++ b/test/fixture/custom.ejs
@@ -1,1 +1,1 @@
-<p>{{= message}}</p>
+<p><?= message ?></p>

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -78,8 +78,7 @@ describe("ejs middleware", function(){
       },
       options = {
         views: __dirname + "/fixture",
-        open: "{{",
-        close: "}}"
+        delimiter: '?'
       };
 
     ejsamd.middleware(options)(request, response);


### PR DESCRIPTION
I've updated the package on package.json. Everything worked out of the box expect for the custom 
delimiters that have a different behavior now as discussed in https://github.com/mde/ejs/issues/55
